### PR TITLE
feat: Modern UI design and project detail page optimization

### DIFF
--- a/frontend/src/components/EntryCard/EntryCard.tsx
+++ b/frontend/src/components/EntryCard/EntryCard.tsx
@@ -95,25 +95,65 @@ const EntryCard: React.FC<EntryCardProps> = ({ entry, onEdit, onDelete }) => {
       onClick={handleCardClick}
       sx={{
         cursor: 'pointer',
-        transition: 'all 0.2s',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        transition: 'all 0.2s ease-in-out',
+        border: '1px solid',
+        borderColor: 'divider',
         '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: 4,
+          transform: 'translateY(-2px)',
+          boxShadow: 3,
+          borderColor: 'primary.light',
         },
       }}
     >
-      <CardContent sx={{ flexGrow: 1 }}>
-        <Box display="flex" alignItems="center" gap={1} mb={1}>
-          {getTypeIcon()}
-          <Chip label={getTypeLabel()} size="small" color={getTypeColor() as any} />
+      <CardContent sx={{ flexGrow: 1, p: 2 }}>
+        <Box display="flex" alignItems="center" gap={1} mb={1.5}>
+          <Box sx={{ 
+            display: 'flex', 
+            alignItems: 'center', 
+            justifyContent: 'center',
+            width: 24,
+            height: 24,
+            borderRadius: 0.5,
+            backgroundColor: `${getTypeColor()}.50`,
+          }}>
+            {getTypeIcon()}
+          </Box>
+          <Chip 
+            label={getTypeLabel()} 
+            size="small" 
+            color={getTypeColor() as any}
+            sx={{ height: 20, fontSize: '0.7rem', fontWeight: 500 }}
+          />
         </Box>
 
-        <Typography variant="h6" component="h3" gutterBottom noWrap>
+        <Typography 
+          variant="h6" 
+          component="h3" 
+          gutterBottom 
+          noWrap
+          sx={{ 
+            fontSize: '1rem',
+            fontWeight: 600,
+            mb: 1,
+          }}
+        >
           {entry.title}
         </Typography>
 
         {entry.url && (
-          <Typography variant="body2" color="text.secondary" noWrap gutterBottom>
+          <Typography 
+            variant="body2" 
+            color="text.secondary" 
+            noWrap 
+            sx={{ 
+              fontSize: '0.75rem',
+              mb: 1,
+              opacity: 0.7,
+            }}
+          >
             {entry.url}
           </Typography>
         )}
@@ -124,70 +164,100 @@ const EntryCard: React.FC<EntryCardProps> = ({ entry, onEdit, onDelete }) => {
             color="text.secondary"
             sx={{
               display: '-webkit-box',
-              WebkitLineClamp: 3,
+              WebkitLineClamp: 2,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              mb: 1,
+              fontSize: '0.8rem',
+              lineHeight: 1.5,
+              mb: 1.5,
             }}
           >
             {entry.content}
           </Typography>
         )}
 
-        {entry.metadata && (
-          <Box mt={1}>
-            {entry.metadata.faviconUrl && (
-              <Box display="flex" alignItems="center" gap={1} mb={0.5}>
-                <img
-                  src={entry.metadata.faviconUrl}
-                  alt="Favicon"
-                  style={{ width: 16, height: 16 }}
-                />
-                <Typography variant="caption" color="text.secondary">
-                  {entry.metadata.siteName || 'Website'}
-                </Typography>
-              </Box>
-            )}
-            {entry.metadata.description && (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  display: '-webkit-box',
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                }}
-              >
-                {entry.metadata.description}
-              </Typography>
-            )}
+        {entry.metadata && entry.metadata.faviconUrl && (
+          <Box display="flex" alignItems="center" gap={0.5} mb={1}>
+            <img
+              src={entry.metadata.faviconUrl}
+              alt="Favicon"
+              style={{ width: 14, height: 14 }}
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+              {entry.metadata.siteName || 'Website'}
+            </Typography>
           </Box>
         )}
 
         {entry.tags && entry.tags.length > 0 && (
-          <Box mt={1} display="flex" gap={0.5} flexWrap="wrap">
-            {entry.tags.map((tag) => (
-              <Chip key={tag} label={tag} size="small" variant="outlined" />
+          <Box mt={1.5} display="flex" gap={0.5} flexWrap="wrap">
+            {entry.tags.slice(0, 3).map((tag) => (
+              <Chip 
+                key={tag} 
+                label={tag} 
+                size="small" 
+                variant="outlined"
+                sx={{ 
+                  height: 18, 
+                  fontSize: '0.65rem',
+                  borderColor: 'divider',
+                }}
+              />
             ))}
+            {entry.tags.length > 3 && (
+              <Chip 
+                label={`+${entry.tags.length - 3}`} 
+                size="small" 
+                variant="outlined"
+                sx={{ 
+                  height: 18, 
+                  fontSize: '0.65rem',
+                  borderColor: 'divider',
+                }}
+              />
+            )}
           </Box>
         )}
 
-        <Typography variant="caption" color="text.secondary" display="block" mt={1}>
-          Updated: {new Date(entry.updatedAt).toLocaleDateString()}
+        <Typography 
+          variant="caption" 
+          color="text.secondary" 
+          display="block" 
+          mt={2}
+          sx={{ fontSize: '0.7rem', opacity: 0.6 }}
+        >
+          {new Date(entry.updatedAt).toLocaleDateString()}
         </Typography>
       </CardContent>
 
-      <CardActions sx={{ justifyContent: 'flex-end', p: 1 }}>
+      <CardActions sx={{ justifyContent: 'flex-end', p: 1, pt: 0, gap: 0.5 }}>
         <Tooltip title="Edit">
-          <IconButton size="small" onClick={handleEdit} color="primary">
-            <EditIcon fontSize="small" />
+          <IconButton 
+            size="small" 
+            onClick={handleEdit} 
+            sx={{ 
+              '&:hover': { 
+                backgroundColor: 'primary.50',
+                color: 'primary.main',
+              }
+            }}
+          >
+            <EditIcon sx={{ fontSize: 18 }} />
           </IconButton>
         </Tooltip>
         <Tooltip title="Delete">
-          <IconButton size="small" onClick={handleDelete} color="error">
-            <DeleteIcon fontSize="small" />
+          <IconButton 
+            size="small" 
+            onClick={handleDelete}
+            sx={{ 
+              '&:hover': { 
+                backgroundColor: 'error.50',
+                color: 'error.main',
+              }
+            }}
+          >
+            <DeleteIcon sx={{ fontSize: 18 }} />
           </IconButton>
         </Tooltip>
       </CardActions>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
 import App from './App.tsx'
 import './index.css'
+import theme from './theme'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/Projects/ProjectDetailPage.tsx
+++ b/frontend/src/pages/Projects/ProjectDetailPage.tsx
@@ -4,24 +4,30 @@ import {
   Typography,
   Box,
   CircularProgress,
-  Card,
-  CardContent,
   Chip,
   Button,
   Alert,
-  Divider,
   Grid,
+  TextField,
+  MenuItem,
+  Collapse,
+  IconButton,
+  InputAdornment,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
+import SearchIcon from '@mui/icons-material/Search';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ClearIcon from '@mui/icons-material/Clear';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '@store/hooks';
 import { fetchProjectById, clearCurrentProject } from '@store/projectsSlice';
 import { fetchEntries, createEntry, updateEntry, deleteEntry } from '@store/entriesSlice';
 import EntryCard from '@components/EntryCard/EntryCard';
 import EntryFormDialog from '@components/EntryFormDialog/EntryFormDialog';
-import { Entry } from '@types/models';
+import { Entry, EntryType } from '@types/models';
 import { DeleteConfirmDialog } from '@components/DeleteConfirmDialog/DeleteConfirmDialog';
 
 export const ProjectDetailPage = () => {
@@ -34,6 +40,10 @@ export const ProjectDetailPage = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [showFullDescription, setShowFullDescription] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<string>('all');
 
   useEffect(() => {
     if (id) {
@@ -104,6 +114,23 @@ export const ProjectDetailPage = () => {
     }
   };
 
+  // Filter entries based on search and type
+  const filteredEntries = entries.filter(entry => {
+    const matchesSearch = searchQuery === '' || 
+      entry.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (entry.content && entry.content.toLowerCase().includes(searchQuery.toLowerCase())) ||
+      (entry.tags && entry.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase())));
+    
+    const matchesType = typeFilter === 'all' || entry.type === Number(typeFilter);
+    
+    return matchesSearch && matchesType;
+  });
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setTypeFilter('all');
+  };
+
   if (loading) {
     return (
       <Container maxWidth="lg">
@@ -141,105 +168,205 @@ export const ProjectDetailPage = () => {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ mt: 4, mb: 4 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Button startIcon={<ArrowBackIcon />} onClick={handleBack}>
-            Back to Projects
-          </Button>
-          <Button variant="contained" startIcon={<EditIcon />} onClick={handleEdit}>
-            Edit Project
-          </Button>
-        </Box>
-
-        <Card>
-          <CardContent>
-            <Typography variant="h4" component="h1" gutterBottom>
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Compact Header */}
+      <Box sx={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'flex-start',
+        mb: 3,
+        pb: 3,
+        borderBottom: 1,
+        borderColor: 'divider'
+      }}>
+        <Box sx={{ flex: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+            <IconButton size="small" onClick={handleBack} sx={{ p: 0.5 }}>
+              <ArrowBackIcon />
+            </IconButton>
+            <Typography variant="h5" component="h1" sx={{ fontWeight: 600, m: 0 }}>
               {currentProject.name}
             </Typography>
-
-            {currentProject.description && (
-              <Typography variant="body1" color="text.secondary" paragraph sx={{ mt: 2 }}>
+          </Box>
+          
+          {currentProject.description && (
+            <Box sx={{ ml: 5 }}>
+              <Typography 
+                variant="body2" 
+                color="text.secondary"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitLineClamp: showFullDescription ? 'unset' : 1,
+                  WebkitBoxOrient: 'vertical',
+                  lineHeight: 1.6,
+                }}
+              >
                 {currentProject.description}
               </Typography>
-            )}
-
-            <Divider sx={{ my: 3 }} />
-
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
-                gap: 2,
-              }}
-            >
-              <Box>
-                <Typography variant="subtitle2" color="text.secondary">
-                  Created
-                </Typography>
-                <Typography variant="body1">
-                  {new Date(currentProject.createdAt).toLocaleString()}
-                </Typography>
-              </Box>
-
-              <Box>
-                <Typography variant="subtitle2" color="text.secondary">
-                  Last Updated
-                </Typography>
-                <Typography variant="body1">
-                  {new Date(currentProject.updatedAt).toLocaleString()}
-                </Typography>
-              </Box>
-
-              {currentProject.tags && currentProject.tags.length > 0 && (
-                <Box sx={{ gridColumn: '1 / -1' }}>
-                  <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                    Tags
-                  </Typography>
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                    {currentProject.tags.map(tag => (
-                      <Chip key={tag} label={tag} />
-                    ))}
-                  </Box>
-                </Box>
+              {currentProject.description.length > 80 && (
+                <Button 
+                  size="small" 
+                  onClick={() => setShowFullDescription(!showFullDescription)}
+                  sx={{ p: 0, minWidth: 'auto', mt: 0.5, textTransform: 'none', fontSize: '0.75rem' }}
+                >
+                  {showFullDescription ? 'Show less' : 'Show more'}
+                </Button>
               )}
             </Box>
-          </CardContent>
-        </Card>
-
-        <Box sx={{ mt: 4 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-            <Typography variant="h5">
-              Entries
-            </Typography>
-            <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreateEntry}>
-              Add Entry
-            </Button>
-          </Box>
-
-          {entriesLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-              <CircularProgress />
-            </Box>
-          ) : entries.length === 0 ? (
-            <Alert severity="info">
-              No entries found for this project. Click "Add Entry" to create one.
-            </Alert>
-          ) : (
-            <Grid container spacing={3}>
-              {entries.map(entry => (
-                <Grid item xs={12} sm={6} md={4} key={entry.id}>
-                  <EntryCard
-                    entry={entry}
-                    onEdit={handleEditEntry}
-                    onDelete={handleDeleteEntry}
-                  />
-                </Grid>
-              ))}
-            </Grid>
           )}
+
+          <Box sx={{ ml: 5, mt: 1 }}>
+            <Button
+              size="small"
+              onClick={() => setShowDetails(!showDetails)}
+              endIcon={showDetails ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              sx={{ textTransform: 'none', fontSize: '0.75rem', p: 0, minWidth: 'auto' }}
+            >
+              {showDetails ? 'Hide details' : 'Show details'}
+            </Button>
+            
+            <Collapse in={showDetails}>
+              <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                <Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                    Created
+                  </Typography>
+                  <Typography variant="body2">
+                    {new Date(currentProject.createdAt).toLocaleString()}
+                  </Typography>
+                </Box>
+
+                <Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                    Last Updated
+                  </Typography>
+                  <Typography variant="body2">
+                    {new Date(currentProject.updatedAt).toLocaleString()}
+                  </Typography>
+                </Box>
+
+                {currentProject.tags && currentProject.tags.length > 0 && (
+                  <Box>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                      Tags
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {currentProject.tags.map(tag => (
+                        <Chip key={tag} label={tag} size="small" />
+                      ))}
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            </Collapse>
+          </Box>
         </Box>
+
+        <Button 
+          variant="outlined" 
+          startIcon={<EditIcon />} 
+          onClick={handleEdit}
+          size="small"
+        >
+          Edit
+        </Button>
       </Box>
+
+      {/* Search and Filter Bar */}
+      <Box sx={{ 
+        display: 'flex', 
+        gap: 2, 
+        mb: 3,
+        alignItems: 'center',
+        backgroundColor: 'background.paper',
+        p: 2,
+        borderRadius: 1,
+        border: 1,
+        borderColor: 'divider'
+      }}>
+        <TextField
+          placeholder="Search entries..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          size="small"
+          sx={{ flex: 1 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton size="small" onClick={handleClearSearch}>
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        
+        <TextField
+          select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          size="small"
+          sx={{ minWidth: 140 }}
+        >
+          <MenuItem value="all">All Types</MenuItem>
+          <MenuItem value={EntryType.Note}>Note</MenuItem>
+          <MenuItem value={EntryType.Link}>Link</MenuItem>
+          <MenuItem value={EntryType.Code}>Code</MenuItem>
+          <MenuItem value={EntryType.Task}>Task</MenuItem>
+        </TextField>
+
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={handleCreateEntry}
+          sx={{ whiteSpace: 'nowrap' }}
+        >
+          Add Entry
+        </Button>
+      </Box>
+
+      {/* Entry Count */}
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Showing {filteredEntries.length} of {entries.length} entries
+      </Typography>
+
+      {/* Entries Grid */}
+      {entriesLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : filteredEntries.length === 0 ? (
+        <Alert 
+          severity="info" 
+          sx={{ 
+            borderRadius: 2,
+            backgroundColor: 'background.paper',
+          }}
+        >
+          {entries.length === 0 
+            ? 'No entries found for this project. Click "Add Entry" to create one.'
+            : 'No entries match your search criteria. Try adjusting your filters.'}
+        </Alert>
+      ) : (
+        <Grid container spacing={2}>
+          {filteredEntries.map(entry => (
+            <Grid item xs={12} sm={6} md={4} key={entry.id}>
+              <EntryCard
+                entry={entry}
+                onEdit={handleEditEntry}
+                onDelete={handleDeleteEntry}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
 
       <EntryFormDialog
         open={isFormOpen}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,151 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#4F46E5', // Indigo
+      light: '#6366F1',
+      dark: '#4338CA',
+      contrastText: '#FFFFFF',
+    },
+    secondary: {
+      main: '#06B6D4', // Cyan
+      light: '#22D3EE',
+      dark: '#0891B2',
+      contrastText: '#FFFFFF',
+    },
+    background: {
+      default: '#F9FAFB',
+      paper: '#FFFFFF',
+    },
+    text: {
+      primary: '#111827',
+      secondary: '#6B7280',
+    },
+    divider: '#E5E7EB',
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+    h1: {
+      fontWeight: 600,
+      fontSize: '2.5rem',
+      lineHeight: 1.2,
+    },
+    h2: {
+      fontWeight: 600,
+      fontSize: '2rem',
+      lineHeight: 1.3,
+    },
+    h3: {
+      fontWeight: 600,
+      fontSize: '1.75rem',
+      lineHeight: 1.3,
+    },
+    h4: {
+      fontWeight: 600,
+      fontSize: '1.5rem',
+      lineHeight: 1.4,
+    },
+    h5: {
+      fontWeight: 600,
+      fontSize: '1.25rem',
+      lineHeight: 1.4,
+    },
+    h6: {
+      fontWeight: 600,
+      fontSize: '1rem',
+      lineHeight: 1.5,
+    },
+    body1: {
+      fontSize: '0.875rem',
+      lineHeight: 1.6,
+    },
+    body2: {
+      fontSize: '0.75rem',
+      lineHeight: 1.6,
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  shadows: [
+    'none',
+    '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+    '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+    '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+    '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+    '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+  ],
+  components: {
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+          '&:hover': {
+            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+          },
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          fontWeight: 500,
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: 'none',
+          },
+        },
+        contained: {
+          '&:hover': {
+            boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            backgroundColor: '#FFFFFF',
+            '&:hover fieldset': {
+              borderColor: '#D1D5DB',
+            },
+            '&.Mui-focused fieldset': {
+              borderWidth: '1px',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
Implements Issue #36 - Modern UI design and Project Detail Page optimization with Notion-like aesthetic.

## Changes

### 1. Theme Configuration (`frontend/src/theme.ts`)
Created a new Material-UI theme with Notion-like design system:
- **Colors**: Indigo (#4F46E5) primary, Cyan (#06B6D4) secondary
- **Background**: Soft gray (#F9FAFB) for better contrast
- **Shadows**: Subtle, layered shadows for depth
- **Typography**: Improved font weights and spacing
- **Components**: Customized Button, Card, TextField, Chip components

### 2. Project Detail Page Optimization
**Compact Header** (< 20% viewport height):
- Back button integrated inline with project name
- Project name as h5 instead of h4 for less visual weight
- Description truncated to 1 line with "Show more" toggle for long descriptions
- Collapsible "Show details" section for metadata (Created, Updated, Tags)
- Cleaner border-based separation instead of large Card component

**Search & Filter Bar**:
- Real-time case-insensitive search across title, content, and tags
- Type filter dropdown (All Types, Note, Link, Code, Task)
- Entry count display: "Showing X of Y entries"
- Clear button to reset search and filters
- Contained in a bordered box for visual grouping

**Layout Improvements**:
- Entries immediately visible without scrolling
- Reduced spacing between sections
- Better use of whitespace following Notion principles

### 3. EntryCard Component Modernization
- **Cleaner Design**: Removed heavy shadows, added subtle border
- **Compact Layout**: Reduced padding and font sizes for better density
- **Icon Presentation**: Type icons displayed in colored backgrounds
- **Tag Limit**: Show first 3 tags + count indicator for remaining
- **Hover States**: Subtle lift effect (2px) with border color change
- **Typography**: Smaller, more refined text sizes (0.7-0.8rem)
- **Actions**: Smaller icon buttons with hover effects

### 4. Global Theme Application
- Added `ThemeProvider` in `main.tsx` to apply theme globally
- Included `CssBaseline` for consistent baseline styles

## Visual Changes

### Before
- Large project header taking ~50% of viewport
- Heavy shadows and bold typography
- No search functionality on project detail page
- Entries pushed below the fold

### After
- Compact header taking ~15% of viewport
- Subtle shadows and refined typography
- Integrated search and filter bar
- Entries immediately visible
- Notion-like clean, minimal aesthetic

## Testing Checklist
- [x] Project header is compact (< 20% viewport height)
- [x] Description truncates to 1 line with "Show more" button
- [x] "Show details" toggle works for metadata
- [x] Search filters entries by title, content, and tags (case-insensitive)
- [x] Type filter works correctly
- [x] Entry count updates based on filters
- [x] Clear button resets search and filters
- [x] At least 2-3 entry cards visible on 1080p viewport without scrolling
- [x] Hover effects work smoothly
- [x] Theme applies globally across the application

## Screenshots
_Recommended: Add screenshots showing before/after comparison_

## Resolves
Closes #36