### PR TITLE
Fix: Update entry types and validation for Link entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,10 @@ Brain Shelf is a centralized storage application for organizing and managing use
   - Full-text search across all content
   - Filter by descriptions, tags, and entry types
   - Autocomplete suggestions
-- **Automatic Metadata Extraction**: 
-  - Automatically extract page titles, descriptions, keywords, and preview images from links
-  - Minimal manual input required
 - **Entry Types**:
-  - 🔗 Links (with automatic metadata extraction)
+  - 🔗 Links
   - 📝 Notes
-  - ⚙️ Settings
+  - 💻 Code
   - 📋 Instructions
 
 ## Technology Stack

--- a/backend/src/BrainShelf.Api/Validators/CreateEntryDtoValidator.cs
+++ b/backend/src/BrainShelf.Api/Validators/CreateEntryDtoValidator.cs
@@ -29,7 +29,7 @@ public class CreateEntryDtoValidator : AbstractValidator<CreateEntryDto>
 
         RuleFor(x => x.Type)
             .IsInEnum()
-            .WithMessage("Entry type must be Link, Note, Setting, or Instruction");
+            .WithMessage("Entry type must be Link, Note, Code, or Task");
 
         // Type-specific validation for Link entries
         When(x => x.Type == EntryType.Link, () =>
@@ -40,17 +40,15 @@ public class CreateEntryDtoValidator : AbstractValidator<CreateEntryDto>
                 .Must(BeAValidUrl)
                 .WithMessage("URL must be a valid HTTP or HTTPS URL");
 
-            RuleFor(x => x.Content)
-                .NotEmpty()
-                .WithMessage("Content is required for Link entries");
+            // Content is optional for Link entries - will be auto-extracted from URL
         });
 
-        // Type-specific validation for Note, Setting, and Instruction entries
-        When(x => x.Type == EntryType.Note || x.Type == EntryType.Setting || x.Type == EntryType.Instruction, () =>
+        // Type-specific validation for Note, Code, and Task entries
+        When(x => x.Type == EntryType.Note || x.Type == EntryType.Code || x.Type == EntryType.Task, () =>
         {
             RuleFor(x => x.Content)
                 .NotEmpty()
-                .WithMessage($"Content is required for {nameof(EntryType.Note)}, {nameof(EntryType.Setting)}, and {nameof(EntryType.Instruction)} entries");
+                .WithMessage("Content is required for Note, Code, and Task entries");
         });
 
         RuleFor(x => x.Url)

--- a/backend/src/BrainShelf.Api/Validators/UpdateEntryDtoValidator.cs
+++ b/backend/src/BrainShelf.Api/Validators/UpdateEntryDtoValidator.cs
@@ -25,7 +25,7 @@ public class UpdateEntryDtoValidator : AbstractValidator<UpdateEntryDto>
 
         RuleFor(x => x.Type)
             .IsInEnum()
-            .WithMessage("Entry type must be Link, Note, Setting, or Instruction");
+            .WithMessage("Entry type must be Link, Note, Code, or Task");
 
         // Type-specific validation for Link entries
         When(x => x.Type == EntryType.Link, () =>
@@ -36,17 +36,15 @@ public class UpdateEntryDtoValidator : AbstractValidator<UpdateEntryDto>
                 .Must(BeAValidUrl)
                 .WithMessage("URL must be a valid HTTP or HTTPS URL");
 
-            RuleFor(x => x.Content)
-                .NotEmpty()
-                .WithMessage("Content is required for Link entries");
+            // Content is optional for Link entries - will be auto-extracted from URL
         });
 
-        // Type-specific validation for Note, Setting, and Instruction entries
-        When(x => x.Type == EntryType.Note || x.Type == EntryType.Setting || x.Type == EntryType.Instruction, () =>
+        // Type-specific validation for Note, Code, and Task entries
+        When(x => x.Type == EntryType.Note || x.Type == EntryType.Code || x.Type == EntryType.Task, () =>
         {
             RuleFor(x => x.Content)
                 .NotEmpty()
-                .WithMessage($"Content is required for {nameof(EntryType.Note)}, {nameof(EntryType.Setting)}, and {nameof(EntryType.Instruction)} entries");
+                .WithMessage("Content is required for Note, Code, and Task entries");
         });
 
         RuleFor(x => x.Url)

--- a/backend/src/BrainShelf.Core/Entities/Entry.cs
+++ b/backend/src/BrainShelf.Core/Entities/Entry.cs
@@ -1,7 +1,7 @@
 namespace BrainShelf.Core.Entities;
 
 /// <summary>
-/// Represents an entry (link, note, setting, or instruction) in the system
+/// Represents an entry (link, note, code snippet, or task) in the system
 /// </summary>
 public class Entry : BaseEntity
 {
@@ -23,8 +23,8 @@ public class Entry : BaseEntity
 /// </summary>
 public enum EntryType
 {
-    Link = 0,
-    Note = 1,
-    Setting = 2,
-    Instruction = 3
+    Note = 0,
+    Link = 1,
+    Code = 2,
+    Task = 3
 }

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -52,3 +52,26 @@ This file contains the history of all prompts used during the development of Bra
 
 24. Create PR with bugs fixes and update promts.md, but summurize my promts where we fixes bugs
 
+25. please mount it I would like take a look
+
+26. I don't see the changes (modern UI from PR #37)
+
+27. design the same
+
+28. please generate 100 entities for Test Project
+
+29. Ok, now please implement paging for the entries and I would like to see it in table view, create pr after implementation, if u need any clarification please ask me
+
+30. Clarifications: 1. both (ProjectDetailPage and EntriesPage), 2. all (columns), 3. 20 (rows per page), 4. up to u, 5. server-side (pagination)
+
+31-36. Multiple syntax error fixes in EntriesPage.tsx (JSX corruption, missing braces, duplicate content)
+
+37. please check before commit somethins!!! a lot of errors
+
+38. Multiple JSX structure and enum value fixes
+
+39. Read my task and if i skipped something do it GitHub Copilot - Practical Task (task requirements provided)
+
+40. doen't need admin loyaut skip it. Promts in promts.md file
+
+41. I already have md file with promts!

--- a/frontend/src/components/EntryFormDialog/EntryFormDialog.tsx
+++ b/frontend/src/components/EntryFormDialog/EntryFormDialog.tsx
@@ -88,9 +88,7 @@ const EntryFormDialog: React.FC<EntryFormDialogProps> = ({
           newErrors.url = 'Please enter a valid URL';
         }
       }
-      if (!content.trim()) {
-        newErrors.content = 'Content is required for link entries';
-      }
+      // Content is optional for links - will be auto-extracted from URL
     }
 
     if (type === EntryType.Note || type === EntryType.Code || type === EntryType.Task) {
@@ -181,19 +179,24 @@ const EntryFormDialog: React.FC<EntryFormDialogProps> = ({
           <TextField
             label="Project"
             select
-            value={selectedProjectId || ''}
+            value={projects.length > 0 && selectedProjectId ? selectedProjectId : ''}
             onChange={(e) => setSelectedProjectId(e.target.value)}
             error={!!errors.projectId}
             helperText={errors.projectId || 'Select a project for this entry'}
             fullWidth
             size="small"
             required
+            disabled={projects.length === 0}
           >
-            {projects.map((project) => (
-              <MenuItem key={project.id} value={project.id}>
-                {project.name}
-              </MenuItem>
-            ))}
+            {projects.length === 0 ? (
+              <MenuItem value="">Loading projects...</MenuItem>
+            ) : (
+              projects.map((project) => (
+                <MenuItem key={project.id} value={project.id}>
+                  {project.name}
+                </MenuItem>
+              ))
+            )}
           </TextField>
 
           <TextField

--- a/frontend/src/pages/Entries/EntriesPage.tsx
+++ b/frontend/src/pages/Entries/EntriesPage.tsx
@@ -80,8 +80,16 @@ export const EntriesPage = () => {
         await dispatch(updateEntry({ id: selectedEntry.id, data: entryData })).unwrap();
         dispatch(showSnackbar({ message: 'Entry updated successfully', severity: 'success' }));
       } else {
-        await dispatch(createEntry(entryData)).unwrap();
+        const result = await dispatch(createEntry(entryData)).unwrap();
         dispatch(showSnackbar({ message: 'Entry created successfully', severity: 'success' }));
+        
+        // For Link entries, metadata is extracted asynchronously
+        // Refetch after a short delay to show extracted content
+        if (entryData.type === EntryType.Link) {
+          setTimeout(() => {
+            fetchEntriesData();
+          }, 3000); // Wait 3 seconds for metadata extraction
+        }
       }
       setIsFormOpen(false);
       fetchEntriesData();

--- a/frontend/src/pages/Projects/ProjectDetailPage.tsx
+++ b/frontend/src/pages/Projects/ProjectDetailPage.tsx
@@ -101,21 +101,28 @@ export const ProjectDetailPage = () => {
     setIsDeleteDialogOpen(true);
   };
 
-  const handleFormSubmit = (data: any) => {
+  const handleFormSubmit = async (data: any): Promise<void> => {
     const action = selectedEntry
       ? dispatch(updateEntry({ id: selectedEntry.id, data }))
       : dispatch(createEntry(data));
 
-    action
-      .unwrap()
-      .then(() => {
-        setIsFormOpen(false);
-        setSelectedEntry(null);
-        fetchEntriesData();
-      })
-      .catch((err) => {
-        console.error('Failed to save entry:', err);
-      });
+    try {
+      await action.unwrap();
+      setIsFormOpen(false);
+      setSelectedEntry(null);
+      fetchEntriesData();
+      
+      // For Link entries, metadata is extracted asynchronously
+      // Refetch after a short delay to show extracted content
+      if (!selectedEntry && data.type === EntryType.Link) {
+        setTimeout(() => {
+          fetchEntriesData();
+        }, 3000); // Wait 3 seconds for metadata extraction
+      }
+    } catch (err) {
+      console.error('Failed to save entry:', err);
+      throw err;
+    }
   };
 
   const handleDeleteConfirm = () => {


### PR DESCRIPTION
## Description
Fixes multiple issues with Link entry creation and updates the entry type system to match frontend expectations.

## Changes

### Backend
- **Updated EntryType enum**: Changed from `Link=0, Note=1, Setting=2, Instruction=3` to `Note=0, Link=1, Code=2, Task=3` to match frontend
- **Removed Content requirement for Link entries**: Content is now optional for Links in both Create and Update validators
- **Updated validation messages**: Changed from "Setting/Instruction" to "Code/Task" to reflect correct entry types

### Frontend
- **Removed Content validation for Link entries**: Users no longer need to provide content when creating/updating Links
- **Fixed project select loading state**: Prevents MUI warning about out-of-range values when projects are still loading
- **Added auto-refresh for Link entries**: After creating a Link, the entry list refreshes after 3 seconds to show any background-extracted metadata
- **Fixed async function signature**: Made `handleFormSubmit` properly async in ProjectDetailPage

### Documentation
- **Removed automatic metadata extraction feature**: Since it's not fully working as expected, removed it from the README
- **Updated entry types**: Changed "Settings" to "Code" in the features list

## Technical Details

The main issue was a mismatch between frontend and backend entry type enums. The backend had old values (Setting, Instruction) while the frontend expected (Code, Task). This caused validation errors and prevented entry creation.

Additionally, the validators were requiring Content for Link entries, but since metadata extraction happens asynchronously in the background, this requirement was blocking users from creating Link entries with just a URL.

## Testing
- ✅ Create Link entry with just URL (no content required)
- ✅ Create Note/Code/Task entry (content required)
- ✅ Project select works without console warnings
- ✅ Entry list shows newly created entries immediately
- ✅ Backend builds successfully with updated enum values

## Related
- Fixes the "Content is required for Note, Setting, and Instruction entries" validation error
- Fixes the MUI out-of-range value warning for project select
- Addresses entry type naming inconsistencies between frontend and backend